### PR TITLE
Shared libraries under Linux and OSX are copied with symlinks

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -59,9 +59,9 @@ class FLACConan(ConanFile):
         else:
             if self.options.shared:
                 if self.settings.os == "Macos":
-                    self.copy(pattern="*.dylib", dst="lib", keep_path=False)
+                    self.copy(pattern="*.dylib", dst="lib", keep_path=False, symlinks=True)
                 else:
-                    self.copy(pattern="*.so*", dst="lib", keep_path=False)
+                    self.copy(pattern="*.so*", dst="lib", keep_path=False, symlinks=True)
             else:
                 self.copy(pattern="*.a", dst="lib", keep_path=False)
 


### PR DESCRIPTION
Compiled libraries are now copied as symbolic links. Previously they were copied without symlinks and there was 3 the same files for each library.